### PR TITLE
resultsExplore with summary results

### DIFF
--- a/R/MainFunctions.R
+++ b/R/MainFunctions.R
@@ -389,7 +389,7 @@ resultsExplore <- function(outputFile) {
   results <- paste(readLines(outputFile), collapse="\n")
   results_lines <- strsplit(results, "\n") %>% unlist()
   
-  result <- list()
+  result_data <- list()
   
   for (line in results_lines) {
     # line <- "Candidate model: '198124209' = \"0\"" 
@@ -398,15 +398,23 @@ resultsExplore <- function(outputFile) {
         split_line <- strsplit(line, ":")[[1]]
         key <- trimws(split_line[1]) %>% tolower() %>% gsub(" ", "_", .) 
         value <- trimws(split_line[2]) 
-        result[[key]] <- c(result[[key]], value)
+        result_data[[key]] <- c(result_data[[key]], value)
       } else {
         split_line <- strsplit(line, ":")[[1]]
         key <- trimws(split_line[1]) %>% tolower() %>% gsub(" ", "_", .) 
         value <- trimws(split_line[2])
-        result[[key]] <- value
+        result_data[[key]] <- value
       }
     }
   }
+  
+  
+  result <- list("model" = result_data$best_candidate,
+                 "candidateModels" = result_data$candidate_model,
+                 "countCombinations" = result_data$total_count_combinations,
+                 "countFeatureOperatorPairs" = result_data$total_count_feature_operator_pairs,
+                 "countRulesWithoutConstraints" = result_data$total_count_cutoff_sets,
+                 "countRulesWithConstraints" = result_data$`total_count_candidates_(incl_constraints)`)
   
   return(result)
 }

--- a/tests/testthat/test-MainFunctions.R
+++ b/tests/testthat/test-MainFunctions.R
@@ -193,10 +193,14 @@ test_that("Results Explore", {
                          PrintPerformance = TRUE,
                          Subsumption = TRUE)
   
-  
   outputFile <- paste0(output_path, file_name, ".result")
   results_list <- resultsExplore(outputFile = outputFile)
-  expect_equal(results_list$total_count_cutoff_sets, "16")
-  expect_length(results_list$candidate_model, 32)
+  expect_equal(names(results_list), c("model", 
+                                      "candidateModels", 
+                                      "countCombinations", 
+                                      "countFeatureOperatorPairs", 
+                                      "countRulesWithoutConstraints",
+                                      "countRulesWithConstraints"))
+  expect_length(results_list$candidateModels, 32)
 
 })

--- a/tests/testthat/test-testExplore.R
+++ b/tests/testthat/test-testExplore.R
@@ -39,7 +39,7 @@ test_that("binary_3 trainExplore resultsExplore", {
     outputFile <- paste0(output_path, file_name, ".result")
     results_list <- resultsExplore(outputFile = outputFile)
     # Expected result is 6
-    expect_length(results_list$candidate_model, 8)
+    expect_length(results_list$candidateModels, 8)
     unlink(output_path, recursive = TRUE)
 
 })


### PR DESCRIPTION
resultsExplore output shows only and most tests are passing now

"model" = rule_string,
"candidateModels" = candidate_models,
"countCombinations" = total_count_combinations,
"countFeatureOperatorPairs" = total_count_feature_operator_pairs ,
"countRulesWithoutConstraints" = total_count_cutoff_sets,
"countRulesWithConstraints" = total_count_candidates_(incl_constraints)