### PR TITLE
if condition for win32 unary function fix

### DIFF
--- a/src/C++/Explore/set.cpp
+++ b/src/C++/Explore/set.cpp
@@ -423,7 +423,11 @@ string SET::PrintPerformance() {
   return Result.str();
 }
 
-struct AndJibu : public std ::unary_function<int, void>
+#ifdef _WIN32
+struct AndJibu : public std::unary_function<int, void>
+#else
+struct AndJibu : public std::__unary_function<int, void>
+#endif
 { 
   const boost::dynamic_bitset<> Source;
   boost::dynamic_bitset<> Dest;

--- a/src/C++/Explore/set.cpp
+++ b/src/C++/Explore/set.cpp
@@ -423,11 +423,7 @@ string SET::PrintPerformance() {
   return Result.str();
 }
 
-#ifdef _WIN32
-struct AndJibu : public std::unary_function<int, void>
-#else
-struct AndJibu : public std::__unary_function<int, void>
-#endif
+struct AndJibu : public std ::unary_function<int, void>
 { 
   const boost::dynamic_bitset<> Source;
   boost::dynamic_bitset<> Dest;

--- a/src/C++/Explore/set.cpp
+++ b/src/C++/Explore/set.cpp
@@ -423,7 +423,11 @@ string SET::PrintPerformance() {
   return Result.str();
 }
 
-struct AndJibu : public std ::unary_function<int, void>
+#ifdef __APPLE__
+struct AndJibu : public std::__unary_function<int, void>
+#else
+  struct AndJibu : public std::unary_function<int, void>
+#endif
 { 
   const boost::dynamic_bitset<> Source;
   boost::dynamic_bitset<> Dest;


### PR DESCRIPTION
Added condition for unary function if WIN32

```
#ifdef _WIN32
struct AndJibu : public std::unary_function<int, void>
#else
struct AndJibu : public std::__unary_function<int, void>
#endif
```